### PR TITLE
feat: add `x-ignore-node` field, avoid destroying the custom outbound vless config

### DIFF
--- a/V2RayX/ConfigWindowController.m
+++ b/V2RayX/ConfigWindowController.m
@@ -80,8 +80,16 @@
     
     for (NSDictionary *p in _appDelegate.profiles) {
         // this old conditions is [@"vmess" isEqualToString:p[@"protocol"]] && [p[@"settings"][@"vnext"] count] == 1
-        NSLog(@"protocol: %@", p[@"protocol"]);
-        if (([@"vmess" isEqualToString:p[@"protocol"]] || [@"vless" isEqualToString:p[@"protocol"]]) && [p[@"settings"][@"vnext"] count] == 1) {
+        // NSLog(@"protocol: %@", p[@"protocol"]);
+        // add `x-ignore-node` field, avoid destroying the custom outbounds vless config
+        BOOL isIgnoreNode = NO;
+        if ([p objectForKey:@"x-ignore-node"]) {
+            isIgnoreNode = YES;
+        }
+        if (([@"vmess" isEqualToString:p[@"protocol"]] || [@"vless" isEqualToString:p[@"protocol"]]) &&
+            [p[@"settings"][@"vnext"] count] == 1 &&
+            !isIgnoreNode
+        ) {
             [_profiles addObject:[ServerProfile profilesFromJson:p][0]];
         } else {
             [_outbounds addObject:p];


### PR DESCRIPTION
Due to the destructive update of the configuration field in the large version of Xray core, it is currently recommended to refer to <https://github.com/tzmax/V2RayXS?Tab=readme-ov-file#other-protocols-supported> Update [Xray-core v24.9.7](https://github.com/XTLS/Xray-core/releases/tag/v24.9.7) and above versions, and add `x-ignore-node` when configuring the new VLESS to ignore the damage of the configuration file by V2RayXS.

Example Configuration:
```json
{
	"tag": "new_vless_xhttp",
	"x-ignore-node": true,
	"protocol": "vless",
	"settings": {
		"vnext": [
			{
				"address": "example.com",
				"port": 443,
				"users": [
					{
						"id": ""
					}
				]
			}
		]
	},
	"streamSettings": {
		"network": "xhttp",
		"security": "tls",
		"tlsSettings": {
			"alpn": ["h3"]
		}
		// ……
	}
}
```

> Since it takes a lot of work and time to adapt to the new version, this temporary transition plan will last for a period of time. Thank you for your understanding.